### PR TITLE
Add IsBinCovered to get covered state of selected bin

### DIFF
--- a/CoveragePkg.vhd
+++ b/CoveragePkg.vhd
@@ -392,6 +392,7 @@ package CoveragePkg is
     impure function IsCovered return boolean ;
     impure function IsCovered ( PercentCov : real ) return boolean ;
     impure function GetCov ( PercentCov : real ) return real ;
+    impure function IsBinCovered (BinIndex : integer; PercentCov : real := 100.0) return boolean ;
     impure function GetCov return real ; -- PercentCov of entire model/all bins
     impure function GetItemCount return integer ;
     impure function GetTotalCovGoal ( PercentCov : real ) return integer ;
@@ -2215,6 +2216,18 @@ package body CoveragePkg is
       -- AlertIf(NumBins < 1, OSVVM_ALERTLOG_ID, "CoveragePkg.IsCovered: Empty Coverage Model", failure) ;
       return CountCovHoles(CovTarget) = 0 ;
     end function IsCovered ;
+
+
+    ------------------------------------------------------------
+    impure function IsBinCovered (BinIndex : integer; PercentCov : real := 100.0) return boolean is
+    ------------------------------------------------------------
+    begin
+      if (CovBinPtr(BinIndex).action = COV_COUNT) then
+        return CovBinPtr(BinIndex).PercentCov >= PercentCov;
+      else
+        return false;
+      end if;
+    end function IsBinCovered ;
 
 
     ------------------------------------------------------------


### PR DESCRIPTION
This commit adds a function to the protected type which can be used to get the coverage state of a selected bin. It returns true if the bin was covered, false if not. It also returns false for illegal & ignore bins.

The use case is when you build a coverage model only to get the functional coverage, but using constrained random instead the "intelligent random" methods of the CoveragePkg. For example verifying components in a heuristic way like FIFOs.

``` vhdl
if not(sv_cover.IsBinCovered(7)) then
  -- generate stimulus to cover BIN #7
end if;
```

With the new IsBinCovered function you can know if your have to hit specific coverage goals like writing into the FIFO when it's full, or reading when it's empty.

Maybe there is a simpler method already implemented in CoveragePkg, but I didn't find it.
