### PR TITLE
Add initial FuseSoC core file

### DIFF
--- a/osvvm-utility.core
+++ b/osvvm-utility.core
@@ -1,0 +1,80 @@
+CAPI=2:
+
+name : osvvm:osvvm:utility:2020.05
+
+# The Vivado simulator (xsim) does not currently (2020.1) support the VHDL
+# 2008 tee function used by this core.
+#
+# ModelSim ships with OSVVM and maps the library to the system install. This
+# default mapping will likely result in the build failing due to the user not
+# having permission to write to the system library. Removing or commenting out
+# this mapping will allow the local library to be created.
+
+filesets:
+
+  # The OSVVM release notes provide the required compilation order that would
+  # be easiest to fulfill in one fileset. However, there are two different
+  # versions of the vendor coverage API package, one for Aldec and another for
+  # other tools. Therefore, the files are divided into filesets that should be
+  # compiled before and after the coverage API package, along with separate
+  # filesets for the two versions of the coverage API package.
+
+  pre_coverage:
+    files:
+      - NamePkg.vhd
+      - OsvvmGlobalPkg.vhd
+    file_type: vhdlSource-2008
+    logical_name: osvvm
+
+  coverage_api:
+    files: [VendorCovApiPkg.vhd]
+    file_type: vhdlSource-2008
+    logical_name: osvvm
+
+  coverage_api_aldec:
+    files: [VendorCovApiPkg_Aldec.vhd]
+    file_type: vhdlSource-2008
+    logical_name: osvvm
+
+  post_coverage:
+    files:
+      - TranscriptPkg.vhd
+      - TextUtilPkg.vhd
+      - AlertLogPkg.vhd
+      - MessagePkg.vhd
+      - SortListPkg_int.vhd
+      - RandomBasePkg.vhd
+      - RandomPkg.vhd
+      - CoveragePkg.vhd
+      - MemoryPkg.vhd
+      - ScoreboardGenericPkg.vhd
+      - ScoreboardPkg_slv.vhd
+      - ScoreboardPkg_int.vhd
+      - ResolutionPkg.vhd
+      - TbUtilPkg.vhd
+      - OsvvmContext.vhd
+    file_type: vhdlSource-2008
+    logical_name: osvvm
+
+targets:
+
+  default: &default
+    filesets:
+      - pre_coverage
+      - "tool_rivierapro?  (coverage_api_aldec)"
+      - "!tool_rivierapro? (coverage_api)"
+      - post_coverage
+    tools:
+      # GHDLs compile-osvvm script currently sets the following options for
+      # building OSVVM:
+      #
+      # -fexplicit -frelaxed-rules --no-vital-checks --warn-binding
+      # --mb-comments
+      #
+      # The build will fail without relaxed-rules. The default -Whide option
+      # produced a number of warnings in the coverage package that we will
+      # ignore.
+      #
+      ghdl:
+        analyze_options: ["-frelaxed-rules", "-Wno-hide"]
+

--- a/osvvm-utility.core
+++ b/osvvm-utility.core
@@ -2,7 +2,7 @@ CAPI=2:
 
 #  This file is part of OSVVM.
 #
-#  (c) Crown Copyright 2020
+#  Copyright (c) 2020 by UK Crown
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.

--- a/osvvm-utility.core
+++ b/osvvm-utility.core
@@ -1,5 +1,21 @@
 CAPI=2:
 
+#  This file is part of OSVVM.
+#
+#  (c) Crown Copyright 2020
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
 name : osvvm:osvvm:utility:2020.05
 
 # The Vivado simulator (xsim) does not currently (2020.1) support the VHDL


### PR DESCRIPTION
Support for [FuseSoC](https://github.com/olofk/fusesoc) will ease use of OSVVM with FuseSoC-built designs, allowing specification of compatible OSVVM versions and hopefully easing support for multiple simulators via FuseSoC's [Edalize](https://github.com/olofk/edalize) backend.

FuseSoC uses a `vendor:library:name:version` (VLNV) naming convention for cores. This core would be used as `osvvm:osvvm:utility:YYYY.MM`, leaving space for future core files such as the model library to use their own names under the `osvvm:osvvm` space.

While this core file would continue to be updated with OSVVM releases, it would make sense to add copies for each release to the [standard FuseSoC core library](https://github.com/fusesoc/fusesoc-cores). @olofk created [a core in the old FuseSoC standard core library](https://github.com/openrisc/orpsoc-cores/blob/master/cores/osvvm/osvvm-2015.06.core) using the older FuseSoC core API which could be replaced by this core.