### PR TITLE
Changed CreateClock to use simulator resolution rather than arbitrary…

### DIFF
--- a/TbUtilPkg.vhd
+++ b/TbUtilPkg.vhd
@@ -908,9 +908,9 @@ package body TbUtilPkg is
     else
       -- Schedule s.t. all assignments after the first occur on delta cycle 0   
       Clk <= '0', '1' after LOW_TIME ; 
-      wait for period - 1 ns ; -- allows after on future Clk <= '0'
+      wait for period - t_sim_resolution ; -- allows after on future Clk <= '0'
       loop 
-        Clk <= '0' after 1 ns, '1' after LOW_TIME + 1 ns ; 
+        Clk <= '0' after t_sim_resolution, '1' after LOW_TIME + t_sim_resolution ; 
         wait for period ; 
       end loop ; 
     end if ; 


### PR DESCRIPTION
Ran into a problem with CreateClock on a testbench that had a clock of `tAdcClk : time := 20 ns / 11` because the half-period of the clock was below the 1 ns padding that CreateClock uses to put the transitions on the first delta cycle.

Switched to t_sim_resolution instead, which should be safe for all clock rates and even plays nicely with absurd things like 10 ns simulator resolutions.