### PR TITLE
WaitForLevel with Timeout, Add Signed Scoreboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ as submodules of [OsvvmLibraries](https://github.com/osvvm/OsvvmLibraries).
 **Documentation:** [PDF Documentation](https://github.com/OSVVM/Documentation)  
 
 ## Copyright and License
-Copyright (C) 2006-2022 by [SynthWorks Design Inc.](http://www.synthworks.com/)  
-Copyright (C) 2022 by [OSVVM Authors](AUTHORS.md)   
+Copyright (C) 2006-2024 by [SynthWorks Design Inc.](http://www.synthworks.com/)  
+Copyright (C) 2022-2024 by [OSVVM Authors](AUTHORS.md)   
 
 This file is part of OSVVM.
 

--- a/ScoreboardPkg_signed.vhd
+++ b/ScoreboardPkg_signed.vhd
@@ -1,6 +1,6 @@
 --
---  File Name:         ScoreBoardPkg_int.vhd
---  Design Unit Name:  ScoreBoardPkg_int
+--  File Name:         ScoreBoardPkg_signed.vhd
+--  Design Unit Name:  ScoreBoardPkg_signed
 --  Revision:          STANDARD VERSION
 --
 --  Maintainer:        Jim Lewis      email:  jim@synthworks.com

--- a/ScoreboardPkg_signed.vhd
+++ b/ScoreboardPkg_signed.vhd
@@ -49,7 +49,7 @@ library ieee ;
   use ieee.numeric_std.all ;
 
 
-package ScoreBoardPkg_int is new work.ScoreboardGenericPkg
+package ScoreBoardPkg_signed is new work.ScoreboardGenericPkg
   generic map (
     ExpectedType        => signed,
     ActualType          => signed,

--- a/ScoreboardPkg_signed.vhd
+++ b/ScoreboardPkg_signed.vhd
@@ -1,0 +1,59 @@
+--
+--  File Name:         ScoreBoardPkg_int.vhd
+--  Design Unit Name:  ScoreBoardPkg_int
+--  Revision:          STANDARD VERSION
+--
+--  Maintainer:        Jim Lewis      email:  jim@synthworks.com
+--  Contributor(s):
+--     Jim Lewis          email:  jim@synthworks.com
+--
+--
+--  Description:
+--    Instance of Generic Package ScoreboardGenericPkg for integer
+--
+--  Developed for:
+--        SynthWorks Design Inc.
+--        VHDL Training Classes
+--        11898 SW 128th Ave.  Tigard, Or  97223
+--        http://www.SynthWorks.com
+--
+--  Revision History:
+--    Date      Version    Description
+--    08/2012   2012.08    Generic Instance of ScoreboardGenericPkg
+--    08/2014   2013.08    Updated interface for Match and to_string
+--    11/2016   2016.11    Released as part of OSVVM library
+--    01/2020   2020.01    Updated Licenses to Apache
+--
+--
+--  This file is part of OSVVM.
+--  
+--  Copyright (c) 2006 - 2020 by SynthWorks Design Inc.  
+--  
+--  Licensed under the Apache License, Version 2.0 (the "License");
+--  you may not use this file except in compliance with the License.
+--  You may obtain a copy of the License at
+--  
+--      https://www.apache.org/licenses/LICENSE-2.0
+--  
+--  Unless required by applicable law or agreed to in writing, software
+--  distributed under the License is distributed on an "AS IS" BASIS,
+--  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+--  See the License for the specific language governing permissions and
+--  limitations under the License.
+--  
+
+use std.textio.all ;
+
+library ieee ;
+  use ieee.std_logic_1164.all ;
+  use ieee.numeric_std.all ;
+
+
+package ScoreBoardPkg_int is new work.ScoreboardGenericPkg
+  generic map (
+    ExpectedType        => signed,
+    ActualType          => signed,
+    Match               => "=",  
+    expected_to_string  => to_hstring,
+    actual_to_string    => to_hstring
+  ) ;  

--- a/TbUtilPkg.vhd
+++ b/TbUtilPkg.vhd
@@ -287,6 +287,10 @@ package TbUtilPkg is
   procedure WaitForLevel ( signal A : in boolean ) ;
   procedure WaitForLevel ( signal A : in std_logic ; Polarity : std_logic := '1' ) ;
 
+  procedure WaitForLevelTimeout ( signal A : in boolean ; constant TimeOut : time; variable TimeOutReached : out boolean);
+  procedure WaitForLevelTimeout ( signal A : in std_logic ; constant TimeOut : time; variable TimeOutReached : out boolean; constant Polarity : std_logic := '1');
+
+
   ------------------------------------------------------------
   -- CreateClock,  CreateReset
   --   Note these do not exit
@@ -1096,7 +1100,34 @@ package body TbUtilPkg is
     end if ;
   end procedure WaitForLevel ;
 
-
+  ------------------------------------------------------------
+  -- WaitForLevelTimeout
+  --   Find a signal at a level or simply pass after timeout
+  ------------------------------------------------------------
+  procedure WaitForLevelTimeout ( signal A : in boolean ; constant TimeOut : time; variable TimeOutReached : out boolean) is 
+  begin
+  	TimeOutReached := false;
+    if not A then 
+      wait until A for TimeOut;
+	  if not A then
+	  	TimeOutReached := true;
+	  end if;
+	else
+    end if ; 
+  end procedure WaitForLevelTimeout ; 
+  
+  procedure WaitForLevelTimeout ( signal A : in std_logic ; constant TimeOut : time; variable TimeOutReached : out boolean ; constant Polarity : std_logic := '1') is 
+  begin
+  	TimeOutReached := false;
+    if A /= Polarity then 
+	    wait until A = Polarity for TimeOut; 
+		if A /= Polarity then
+			TimeOutReached := true;
+		end if;
+    end if ; 
+  end procedure WaitForLevelTimeout ; 
+				
+				
   ------------------------------------------------------------
   -- CreateClock,  CreateReset
   --   Note these do not exit


### PR DESCRIPTION
Came across an issue while writing a test for a FIFO. Testbench blocks because the FIFO is empty and I wait for a data available level. 

Signed Scoreboard is implicitly available in Scoreboard_slv but we dont have to type cast ;) 