### PR TITLE
ONE output folder

### DIFF
--- a/AlertLogPkg.vhd
+++ b/AlertLogPkg.vhd
@@ -1092,10 +1092,10 @@ package body AlertLogPkg is
           write(buf, " at " & to_string(NOW, 1 ns) & " ") ;
           writeline(buf) ;
           ReportAlerts(ReportWhenZero => TRUE) ;
-          if FileExists("OsvvmRun.yml") then
+          if FileExists(REPORTS_DIRECTORY & "OsvvmRun.yml") then
 --          work.ReportPkg.EndOfTestReports ;  -- creates circular package issues
             WriteAlertSummaryYaml(
-              FileName        => "OsvvmRun.yml"
+              FileName        => REPORTS_DIRECTORY & "OsvvmRun.yml"
             ) ;
             WriteAlertYaml (
               FileName        => REPORTS_DIRECTORY & GetAlertLogName(ALERTLOG_BASE_ID) & "_alerts.yml"
@@ -5103,7 +5103,7 @@ package body AlertLogPkg is
   ------------------------------------------------------------
   procedure WriteAlertSummaryYaml (FileName : string := "" ; ExternalErrors : AlertCountType := (0,0,0)) is
   ------------------------------------------------------------
-    constant RESOLVED_FILE_NAME : string := IfElse(FileName = "", "OsvvmRun.yml", FileName) ;
+    constant RESOLVED_FILE_NAME : string := IfElse(FileName = "", REPORTS_DIRECTORY & "OsvvmRun.yml", FileName) ;
   begin
     -- synthesis translate_off
     WriteAlertYaml(FileName => RESOLVED_FILE_NAME, ExternalErrors => ExternalErrors, Prefix => "      ", PrintSettings => FALSE, PrintChildren => FALSE, OpenKind => APPEND_MODE) ;

--- a/CoveragePkg.vhd
+++ b/CoveragePkg.vhd
@@ -5106,7 +5106,7 @@ package body CoveragePkg is
     ------------------------------------------------------------
     procedure WriteCovYaml (FileName : string := ""; Coverage : real ; OpenKind : File_Open_Kind := WRITE_MODE) is
     ------------------------------------------------------------
-      constant RESOLVED_FILE_NAME : string := IfElse(FileName = "", "./reports/" & GetAlertLogName & "_cov.yml", FileName) ;
+      constant RESOLVED_FILE_NAME : string := IfElse(FileName = "", REPORTS_DIRECTORY & "./reports/" & GetAlertLogName & "_cov.yml", FileName) ;
       file CovYamlFile : text open OpenKind is RESOLVED_FILE_NAME ;
       variable buf : line ;
     begin
@@ -5699,7 +5699,7 @@ package body CoveragePkg is
     ------------------------------------------------------------
     procedure ReadCovYaml  (FileName : string := ""; Merge : boolean := FALSE) is
     ------------------------------------------------------------
-      constant RESOLVED_FILE_NAME : string := IfElse(FileName = "", "./reports/" & GetAlertLogName & "_cov.yml", FileName) ;
+      constant RESOLVED_FILE_NAME : string := IfElse(FileName = "", REPORTS_DIRECTORY & "./reports/" & GetAlertLogName & "_cov.yml", FileName) ;
       file CovYamlFile : text open READ_MODE is RESOLVED_FILE_NAME ;
       variable buf     : line ;
       variable Found   : boolean ;

--- a/ReportPkg.vhd
+++ b/ReportPkg.vhd
@@ -98,11 +98,11 @@ package body ReportPkg is
     ReportAlerts(ExternalErrors => ExternalErrors, ReportAll => ReportAll) ; 
     
     WriteAlertSummaryYaml(
-      FileName        => "OsvvmRun.yml", 
+      FileName        => REPORTS_DIRECTORY & "OsvvmRun.yml", 
       ExternalErrors  => ExternalErrors
     ) ; 
     WriteCovSummaryYaml (
-      FileName        => "OsvvmRun.yml"
+      FileName        => REPORTS_DIRECTORY & "OsvvmRun.yml"
     ) ;
     WriteAlertYaml (
       FileName        => REPORTS_DIRECTORY &  GetAlertLogName & "_alerts.yml", 

--- a/ScoreboardGenericPkg.vhd
+++ b/ScoreboardGenericPkg.vhd
@@ -2701,7 +2701,7 @@ package body ScoreboardGenericPkg is
     ------------------------------------------------------------
     procedure WriteScoreboardYaml (FileName : string := ""; OpenKind : File_Open_Kind := WRITE_MODE) is
     ------------------------------------------------------------
-      constant RESOLVED_FILE_NAME : string := IfElse(FileName = "", "./reports/" & GetAlertLogName & "_sb.yml", FileName) ;
+      constant RESOLVED_FILE_NAME : string := IfElse(FileName = "", REPORTS_DIRECTORY & "./reports/" & GetAlertLogName & "_sb.yml", FileName) ;
       file SbYamlFile : text open OpenKind is RESOLVED_FILE_NAME ;
       variable buf : line ;
     begin

--- a/ScoreboardPkg_int_c.vhd
+++ b/ScoreboardPkg_int_c.vhd
@@ -2701,7 +2701,7 @@ package body ScoreBoardPkg_int is
     ------------------------------------------------------------
     procedure WriteScoreboardYaml (FileName : string := ""; OpenKind : File_Open_Kind := WRITE_MODE) is
     ------------------------------------------------------------
-      constant RESOLVED_FILE_NAME : string := IfElse(FileName = "", "./reports/" & GetAlertLogName & "_sb.yml", FileName) ; 
+      constant RESOLVED_FILE_NAME : string := IfElse(FileName = "", REPORTS_DIRECTORY & "./reports/" & GetAlertLogName & "_sb.yml", FileName) ; 
       file SbYamlFile : text open OpenKind is RESOLVED_FILE_NAME ;
       variable buf : line ;
     begin

--- a/ScoreboardPkg_slv_c.vhd
+++ b/ScoreboardPkg_slv_c.vhd
@@ -2701,7 +2701,7 @@ package body ScoreBoardPkg_slv is
     ------------------------------------------------------------
     procedure WriteScoreboardYaml (FileName : string := ""; OpenKind : File_Open_Kind := WRITE_MODE) is
     ------------------------------------------------------------
-      constant RESOLVED_FILE_NAME : string := IfElse(FileName = "", "./reports/" & GetAlertLogName & "_sb.yml", FileName) ; 
+      constant RESOLVED_FILE_NAME : string := IfElse(FileName = "", REPORTS_DIRECTORY & "./reports/" & GetAlertLogName & "_sb.yml", FileName) ; 
       file SbYamlFile : text open OpenKind is RESOLVED_FILE_NAME ;
       variable buf : line ;
     begin

--- a/TranscriptPkg.vhd
+++ b/TranscriptPkg.vhd
@@ -49,6 +49,8 @@
 use std.textio.all ;
 package TranscriptPkg is
 
+  constant TRANSCRIPT_DIRECTORY : string := "./sim_tmp/" ;
+
   -- File Identifier to facilitate usage of one transcript file 
   file             TranscriptFile : text ;
   
@@ -114,12 +116,12 @@ package body TranscriptPkg is
   begin
     -- Create Yaml file with list of files.
     if not TranscriptOpened.Get then
-      file_open(TranscriptYamlFile, "OSVVM_transcript.yml", WRITE_MODE) ;
+      file_open(TranscriptYamlFile, TRANSCRIPT_DIRECTORY & "OSVVM_transcript.yml", WRITE_MODE) ;
 --      swrite(buf, "Transcripts: ") ; 
 --      WriteLine(TranscriptYamlFile, buf) ; 
       TranscriptOpened.Set(TRUE) ;
     else
-      file_open(TranscriptYamlFile, "OSVVM_transcript.yml", APPEND_MODE) ;
+      file_open(TranscriptYamlFile, TRANSCRIPT_DIRECTORY & "OSVVM_transcript.yml", APPEND_MODE) ;
     end if ; 
     swrite(buf, "  - " & Name) ; 
     WriteLine(TranscriptYamlFile, buf) ; 


### PR DESCRIPTION
I would very much prefer to put ALL the output in a dedicated folder. This is a first proposal (in combination with a matching PR for the Scripts repo).

Should you be willing to consider this change, I think that REPORTS_DIRECTORY should be moved to someplace else, maybe a separate package which contains configuration?

HTML output is a problem because the links don't work any more. I don't use HTML, so I ignored it for the time being.

Currently, the change in TranscriptPkg.vhd is necessary because of the compilation order. Should you decide to accept this PR, we should add some additional package so that there is only one constant.

Please notice that this is my current "minimally invasive" implementation, so that future merges are easy. Should you consider this PR, I can integrate it more tightly.