### PR TITLE
Created common log interface for LocalPrint.

### DIFF
--- a/AlertLogPkg.vhd
+++ b/AlertLogPkg.vhd
@@ -1047,15 +1047,6 @@ package body AlertLogPkg is
       end if ;
     end procedure IncrementAlertCount ;
 
-    function ToInt(Bool : boolean) return integer is
-    begin
-      if Bool then
-        return 1;
-      else
-        return 0;
-      end if;
-    end;
-
     impure function GetWriteErrorCount(WriteErrorCount : boolean) return string is
     begin
       if WriteErrorCount then
@@ -1131,11 +1122,11 @@ package body AlertLogPkg is
               Str3 => AlertPrefixVar.Get(OSVVM_DEFAULT_ALERT_PREFIX),
               Str4 => GetPrefix(AlertLogID),
               Str5 => GetSuffix(AlertLogID),
-              Val1 => AlertLogJustifyAmountVar,
-              Val2 => ToInt(WriteAlertLevelVar),
-              Val3 => ToInt(WriteAlertTimeVar and not WriteTimeLastVar),
-              Val4 => ToInt(WriteAlertTimeVar and WriteTimeLastVar),
-              Val5 => TimeJustifyAmountVar
+              Int1 => AlertLogJustifyAmountVar,
+              Int2 => TimeJustifyAmountVar,
+              Bool1 => WriteAlertLevelVar,
+              Bool2 => WriteAlertTimeVar and not WriteTimeLastVar,
+              Bool3 => WriteAlertTimeVar and WriteTimeLastVar
             );
           end if;
 
@@ -1152,11 +1143,11 @@ package body AlertLogPkg is
               Str3 => AlertPrefixVar.Get(OSVVM_DEFAULT_ALERT_PREFIX),
               Str4 => GetPrefix(AlertLogID),
               Str5 => GetSuffix(AlertLogID),
-              Val1 => AlertLogJustifyAmountVar,
-              Val2 => ToInt(WriteAlertLevelVar),
-              Val3 => ToInt(WriteAlertTimeVar and not WriteTimeLastVar),
-              Val4 => ToInt(WriteAlertTimeVar and WriteTimeLastVar),
-              Val5 => TimeJustifyAmountVar
+              Int1 => AlertLogJustifyAmountVar,
+              Int2 => TimeJustifyAmountVar,
+              Bool1 => WriteAlertLevelVar,
+              Bool2 => WriteAlertTimeVar and not WriteTimeLastVar,
+              Bool3 => WriteAlertTimeVar and WriteTimeLastVar
             );
           end if;
         end if ;
@@ -2651,11 +2642,11 @@ package body AlertLogPkg is
           Str3 => LogPrefixVar.Get(OSVVM_DEFAULT_LOG_PREFIX),
           Str4 => GetPrefix(AlertLogID),
           Str5 => GetSuffix(AlertLogID),
-          Val1 => AlertLogJustifyAmountVar,
-          Val2 => ToInt(WriteLogLevelVar),
-          Val3 => ToInt(WriteLogTimeVar and not WriteTimeLastVar),
-          Val4 => ToInt(WriteLogTimeVar and WriteTimeLastVar),
-          Val5 => TimeJustifyAmountVar
+          Int1 => AlertLogJustifyAmountVar,
+          Int2 => TimeJustifyAmountVar,
+          Bool1 => WriteLogLevelVar,
+          Bool2 => WriteLogTimeVar and not WriteTimeLastVar,
+          Bool3 => WriteLogTimeVar and WriteTimeLastVar
         );
       end if;
 
@@ -2672,11 +2663,11 @@ package body AlertLogPkg is
           Str3 => LogPrefixVar.Get(OSVVM_DEFAULT_LOG_PREFIX),
           Str4 => GetPrefix(AlertLogID),
           Str5 => GetSuffix(AlertLogID),
-          Val1 => AlertLogJustifyAmountVar,
-          Val2 => ToInt(WriteLogLevelVar),
-          Val3 => ToInt(WriteLogTimeVar and not WriteTimeLastVar),
-          Val4 => ToInt(WriteLogTimeVar and WriteTimeLastVar),
-          Val5 => TimeJustifyAmountVar
+          Int1 => AlertLogJustifyAmountVar,
+          Int2 => TimeJustifyAmountVar,
+          Bool1 => WriteLogLevelVar,
+          Bool2 => WriteLogTimeVar and not WriteTimeLastVar,
+          Bool3 => WriteLogTimeVar and WriteTimeLastVar
         );
       end if;
     end procedure LocalLog ;

--- a/AlertLogPkg.vhd
+++ b/AlertLogPkg.vhd
@@ -1136,6 +1136,7 @@ package body AlertLogPkg is
       -- constant AlertPrefix : string := AlertPrefixVar.Get(OSVVM_DEFAULT_ALERT_PREFIX) ;
       variable StopDueToCount  : boolean := FALSE ;
       variable localAlertLogID : AlertLogIDType ;
+      constant LogSourceName : string := GetAlertLogName(AlertLogID, FoundAlertHierVar, WriteAlertNameVar, AlertLogPtr(AlertLogID).Name.all, AlertLogPtr(AlertLogPtr(AlertLogID).ParentID).Name.all);
     begin
       -- Only write and count when GlobalAlertEnabledVar is enabled
       if GlobalAlertEnabledVar then
@@ -1166,18 +1167,18 @@ package body AlertLogPkg is
                 Msg => Message,
                 LogTime => now,
                 LogLevel => ALERT_NAME(Level),
-                LogSourceName => GetAlertLogName(AlertLogID, FoundAlertHierVar, WriteAlertNameVar, AlertLogPtr(AlertLogID).Name.all, AlertLogPtr(AlertLogPtr(AlertLogID).ParentID).Name.all)
+                LogSourceName => LogSourceName
               );
             end if;
 
             if IsTranscriptOpen then
               WriteToLog(
                 LogDestination => TranscriptFile,
-                LogDestinationPath => "TODO: Provide path to transcriptfile",
+                LogDestinationPath => GetTranscriptFilePath,
                 Msg => Message,
                 LogTime => now,
                 LogLevel => ALERT_NAME(Level),
-                LogSourceName => GetAlertLogName(AlertLogID, FoundAlertHierVar, WriteAlertNameVar, AlertLogPtr(AlertLogID).Name.all, AlertLogPtr(AlertLogPtr(AlertLogID).ParentID).Name.all)
+                LogSourceName => LogSourceName
               );
             end if;
           end if;
@@ -2660,6 +2661,7 @@ package body AlertLogPkg is
       Message      : string ;
       Level        : LogType
     ) is
+      constant LogSourceName : string := GetAlertLogName(AlertLogID, FoundAlertHierVar, WriteLogNameVar, AlertLogPtr(AlertLogID).Name.all, AlertLogPtr(AlertLogPtr(AlertLogID).ParentID).Name.all);
     begin
       if IsOriginalPkg then
         LocalPrint(
@@ -2679,18 +2681,18 @@ package body AlertLogPkg is
             Msg => Message,
             LogTime => now,
             LogLevel => LOG_NAME(Level),
-            LogSourceName => GetAlertLogName(AlertLogID, FoundAlertHierVar, WriteLogNameVar, AlertLogPtr(AlertLogID).Name.all, AlertLogPtr(AlertLogPtr(AlertLogID).ParentID).Name.all)
+            LogSourceName => LogSourceName
           );
         end if;
 
         if IsTranscriptOpen then
           WriteToLog(
             LogDestination => TranscriptFile,
-            LogDestinationPath => "TODO: Provide path to transcriptfile",
+            LogDestinationPath => GetTranscriptFilePath,
             Msg => Message,
             LogTime => now,
             LogLevel => LOG_NAME(Level),
-            LogSourceName => GetAlertLogName(AlertLogID, FoundAlertHierVar, WriteLogNameVar, AlertLogPtr(AlertLogID).Name.all, AlertLogPtr(AlertLogPtr(AlertLogID).ParentID).Name.all)
+            LogSourceName => LogSourceName
           );
         end if;
       end if;

--- a/CommonLogPkg.vhd
+++ b/CommonLogPkg.vhd
@@ -1,0 +1,47 @@
+use std.textio.all;
+
+package CommonLogPkg is
+  constant IsOriginalPkg : boolean;
+  constant NoTime : time := -1 ns;
+  constant NoVal : integer := integer'low;
+
+  -- Converts a log message and associated metadata to a string written to the specified log destination.
+  procedure WriteToLog(
+    ----------------------------------------------------
+    -- Log entry items common to many logging frameworks
+    ----------------------------------------------------
+
+    -- Destination of the log message is either std.textio.output (std output) or a text file object previously opened
+    -- for writing
+    file LogDestination : text;
+    -- Path to LogDestination if it's a file, empty string otherwise
+    LogDestinationPath : string := "";
+    -- Log message
+    Msg : string := "";
+    -- Simulation time associated with the log message
+    LogTime : time := NoTime;
+    -- Level associated with the log message. For example "DEBUG" or "WARNING".
+    LogLevel : string := "";
+    -- Name of the producer of the log message. Hierarchical names use colon as the delimiter.
+    -- For example "parent_component:child_component".
+    LogSourceName : string := "";
+
+    ----------------------------------------------------------------------------------------------------------------------------
+    -- Log entry items less commonly used are passed to the procedure with no-name string and integer parameters which
+    -- meaning is specific to an implementation of the procedure. The documentation below is valid for OSVVM only
+    ----------------------------------------------------------------------------------------------------------------------------
+
+    Str1, -- WritePrefix
+    Str2, -- Write error counter
+    Str3, -- Log or alert
+    Str4, -- Prefix
+    Str5, -- Suffix
+    Str6, Str7, Str8, Str9, Str10 : string := "";
+
+    Val1, -- AlertLogJustifyAmount
+    Val2, -- Write level
+    Val3, -- Write time first
+    Val4, -- Write time last
+    Val5, -- TimeJustifyAmount
+    Val6, Val7, Val8, Val9, Val10 : integer := NoVal);
+end package;

--- a/CommonLogPkg.vhd
+++ b/CommonLogPkg.vhd
@@ -7,10 +7,6 @@ package CommonLogPkg is
 
   -- Converts a log message and associated metadata to a string written to the specified log destination.
   procedure WriteToLog(
-    ----------------------------------------------------
-    -- Log entry items common to many logging frameworks
-    ----------------------------------------------------
-
     -- Destination of the log message is either std.textio.output (std output) or a text file object previously opened
     -- for writing
     file LogDestination : text;
@@ -24,15 +20,6 @@ package CommonLogPkg is
     LogLevel : string := NoString;
     -- Name of the producer of the log message. Hierarchical names use colon as the delimiter.
     -- For example "parent_component:child_component".
-    LogSourceName : string := NoString;
-
-    ----------------------------------------------------------------------------------------------------------------------------
-    -- Log entry items less commonly used are passed to the procedure with no-name string, integer and boolean parameters which
-    -- meaning is specific to an implementation of the procedure. These are not used by OSVVM.
-    ----------------------------------------------------------------------------------------------------------------------------
-
-    Str1, Str2, Str3, Str4, Str5, Str6, Str7, Str8, Str9, Str10 : string := "";
-    Int1, Int2, Int3, Int4, Int5, Int6, Int7, Int8, Int9, Int10 : integer := 0;
-    Bool1, Bool2, Bool3, Bool4, Bool5, Bool6, Bool7, Bool8, Bool9, Bool10 : boolean := false
+    LogSourceName : string := NoString
   );
 end package;

--- a/CommonLogPkg.vhd
+++ b/CommonLogPkg.vhd
@@ -3,7 +3,7 @@ use std.textio.all;
 package CommonLogPkg is
   constant IsOriginalPkg : boolean;
   constant NoTime : time := -1 ns;
-  constant NoVal : integer := integer'low;
+  constant NoString : string := "";
 
   -- Converts a log message and associated metadata to a string written to the specified log destination.
   procedure WriteToLog(
@@ -15,19 +15,19 @@ package CommonLogPkg is
     -- for writing
     file LogDestination : text;
     -- Path to LogDestination if it's a file, empty string otherwise
-    LogDestinationPath : string := "";
+    LogDestinationPath : string := NoString;
     -- Log message
-    Msg : string := "";
+    Msg : string := NoString;
     -- Simulation time associated with the log message
     LogTime : time := NoTime;
     -- Level associated with the log message. For example "DEBUG" or "WARNING".
-    LogLevel : string := "";
+    LogLevel : string := NoString;
     -- Name of the producer of the log message. Hierarchical names use colon as the delimiter.
     -- For example "parent_component:child_component".
-    LogSourceName : string := "";
+    LogSourceName : string := NoString;
 
     ----------------------------------------------------------------------------------------------------------------------------
-    -- Log entry items less commonly used are passed to the procedure with no-name string and integer parameters which
+    -- Log entry items less commonly used are passed to the procedure with no-name string, integer and boolean parameters which
     -- meaning is specific to an implementation of the procedure. The documentation below is valid for OSVVM only
     ----------------------------------------------------------------------------------------------------------------------------
 
@@ -38,10 +38,12 @@ package CommonLogPkg is
     Str5, -- Suffix
     Str6, Str7, Str8, Str9, Str10 : string := "";
 
-    Val1, -- AlertLogJustifyAmount
-    Val2, -- Write level
-    Val3, -- Write time first
-    Val4, -- Write time last
-    Val5, -- TimeJustifyAmount
-    Val6, Val7, Val8, Val9, Val10 : integer := NoVal);
+    Int1, -- AlertLogJustifyAmount
+    Int2, -- TimeJustifyAmount
+    Int3, Int4, Int5, Int6, Int7, Int8, Int9, Int10 : integer := 0;
+
+    Bool1, -- Write level
+    Bool2, -- Write time first
+    Bool3, -- Write time last
+    Bool4, Bool5, Bool6, Bool7, Bool8, Bool9, Bool10 : boolean := false);
 end package;

--- a/CommonLogPkg.vhd
+++ b/CommonLogPkg.vhd
@@ -28,22 +28,11 @@ package CommonLogPkg is
 
     ----------------------------------------------------------------------------------------------------------------------------
     -- Log entry items less commonly used are passed to the procedure with no-name string, integer and boolean parameters which
-    -- meaning is specific to an implementation of the procedure. The documentation below is valid for OSVVM only
+    -- meaning is specific to an implementation of the procedure. These are not used by OSVVM.
     ----------------------------------------------------------------------------------------------------------------------------
 
-    Str1, -- WritePrefix
-    Str2, -- Write error counter
-    Str3, -- Log or alert
-    Str4, -- Prefix
-    Str5, -- Suffix
-    Str6, Str7, Str8, Str9, Str10 : string := "";
-
-    Int1, -- AlertLogJustifyAmount
-    Int2, -- TimeJustifyAmount
-    Int3, Int4, Int5, Int6, Int7, Int8, Int9, Int10 : integer := 0;
-
-    Bool1, -- Write level
-    Bool2, -- Write time first
-    Bool3, -- Write time last
-    Bool4, Bool5, Bool6, Bool7, Bool8, Bool9, Bool10 : boolean := false);
+    Str1, Str2, Str3, Str4, Str5, Str6, Str7, Str8, Str9, Str10 : string := "";
+    Int1, Int2, Int3, Int4, Int5, Int6, Int7, Int8, Int9, Int10 : integer := 0;
+    Bool1, Bool2, Bool3, Bool4, Bool5, Bool6, Bool7, Bool8, Bool9, Bool10 : boolean := false
+  );
 end package;

--- a/CommonLogPkgBody.vhd
+++ b/CommonLogPkgBody.vhd
@@ -1,7 +1,3 @@
-use work.OsvvmGlobalPkg.all;
-use work.TextUtilPkg.all;
-use work.TranscriptPkg.all;
-
 package body CommonLogPkg is
   constant IsOriginalPkg : boolean := true;
 
@@ -17,67 +13,7 @@ package body CommonLogPkg is
     Int1, Int2, Int3, Int4, Int5, Int6, Int7, Int8, Int9, Int10 : integer := 0;
     Bool1, Bool2, Bool3, Bool4, Bool5, Bool6, Bool7, Bool8, Bool9, Bool10 : boolean := false
   ) is
-      alias WritePrefix is Str1;
-      alias WriteErrorCount is Str2;
-      alias LogOrAlert is Str3;
-      alias Prefix is Str4;
-      alias Suffix is Str5;
-
-      alias AlertLogJustifyAmount is Int1;
-      alias TimeJustifyAmount is Int2;
-
-      alias WriteLevel is Bool1;
-      alias WriteTimeFirst is Bool2;
-      alias WriteTimeLast is Bool3;
-
-      variable buf : line ;
-      ------------------------------------------------------------
-      -- Package Local
-      function LeftJustify(A : String;  Amount : integer) return string is
-      ------------------------------------------------------------
-        constant Spaces : string(1 to  maximum(1, Amount)) := (others => ' ') ;
-      begin
-        if A'length >= Amount then
-          return A ;
-        else
-          return A & Spaces(1 to Amount - A'length) ;
-        end if ;
-      end function LeftJustify ;
   begin
-      write(buf, WritePrefix) ; -- Print
-      -- Debug Mode
-      write(buf, WriteErrorCount) ;
-      -- Write Time
-      if WriteTimeFirst then
-        write(buf, justify(to_string(LogTime, GetOsvvmDefaultTimeUnits), TimeJustifyAmount, RIGHT) & "    ") ;
-      end if ;
-      -- Alert or Log
-      write(buf, LogOrAlert) ;
-      -- Level Name, when enabled (default)
-      if WriteLevel then
-        write(buf, "  " & LogLevel) ;
-      end if ;
-      -- AlertLog Name
-      if LogSourceName /= NoString then
-        write(buf, "   in " & LeftJustify(LogSourceName & ',', AlertLogJustifyAmount) ) ;
-      end if ;
-      -- Spacing before message
-      swrite(buf, "  ") ;
-      -- Prefix
-      if Prefix /= "" then
-        write(buf, ' ' & Prefix) ;
-      end if ;
-      -- Message
-      write(buf, " " & Msg) ;
-      -- Suffix
-      if Suffix /= "" then
-        write(buf, ' ' & Suffix) ;
-      end if ;
-      -- Time Last
-      if WriteTimeLast then
-        write(buf, " at " & to_string(LogTime, GetOsvvmDefaultTimeUnits)) ;
-      end if ;
-      WriteLine(buf) ;
   end;
 
 end package body;

--- a/CommonLogPkgBody.vhd
+++ b/CommonLogPkgBody.vhd
@@ -7,11 +7,7 @@ package body CommonLogPkg is
     Msg : string := NoString;
     LogTime : time := NoTime;
     LogLevel : string := NoString;
-    LogSourceName : string := NoString;
-
-    Str1, Str2, Str3, Str4, Str5, Str6, Str7, Str8, Str9, Str10 : string := "";
-    Int1, Int2, Int3, Int4, Int5, Int6, Int7, Int8, Int9, Int10 : integer := 0;
-    Bool1, Bool2, Bool3, Bool4, Bool5, Bool6, Bool7, Bool8, Bool9, Bool10 : boolean := false
+    LogSourceName : string := NoString
   ) is
   begin
   end;

--- a/CommonLogPkgBody.vhd
+++ b/CommonLogPkgBody.vhd
@@ -1,0 +1,78 @@
+use work.OsvvmGlobalPkg.all;
+use work.TextUtilPkg.all;
+use work.TranscriptPkg.all;
+
+package body CommonLogPkg is
+  constant IsOriginalPkg : boolean := true;
+
+  procedure WriteToLog(
+    file LogDestination : text;
+    Msg : string := "";
+    LogTime : time := NoTime;
+    LogLevel : string := "";
+    LogSourceName : string := "";
+    Str1, Str2, Str3, Str4, Str5, Str6, Str7, Str8, Str9, Str10 : string := "";
+    Val1, Val2, Val3, Val4, Val5, Val6, Val7, Val8, Val9, Val10 : integer := NoVal) is
+      alias WritePrefix is Str1;
+      alias WriteErrorCount is Str2;
+      alias LogOrAlert is Str3;
+      alias Prefix is Str4;
+      alias Suffix is Str5;
+
+      alias AlertLogJustifyAmount is Val1;
+      constant WriteLevel : boolean := Val2 = 1;
+      constant WriteTimeFirst : boolean := Val3 = 1;
+      constant WriteTimeLast : boolean := Val4 = 1;
+      alias TimeJustifyAmount is Val5;
+
+      variable buf : line ;
+      ------------------------------------------------------------
+      -- Package Local
+      function LeftJustify(A : String;  Amount : integer) return string is
+      ------------------------------------------------------------
+        constant Spaces : string(1 to  maximum(1, Amount)) := (others => ' ') ;
+      begin
+        if A'length >= Amount then
+          return A ;
+        else
+          return A & Spaces(1 to Amount - A'length) ;
+        end if ;
+      end function LeftJustify ;
+  begin
+      write(buf, WritePrefix) ; -- Print
+      -- Debug Mode
+      write(buf, WriteErrorCount) ;
+      -- Write Time
+      if WriteTimeFirst then
+        write(buf, justify(to_string(LogTime, GetOsvvmDefaultTimeUnits), TimeJustifyAmount, RIGHT) & "    ") ;
+      end if ;
+      -- Alert or Log
+      write(buf, LogOrAlert) ;
+      -- Level Name, when enabled (default)
+      if WriteLevel then
+        write(buf, "  " & LogLevel) ;
+      end if ;
+      -- AlertLog Name
+      if LogSourceName /= "" then
+        write(buf, "   in " & LeftJustify(LogSourceName & ',', AlertLogJustifyAmount) ) ;
+      end if ;
+      -- Spacing before message
+      swrite(buf, "  ") ;
+      -- Prefix
+      if Prefix /= "" then
+        write(buf, ' ' & Prefix) ;
+      end if ;
+      -- Message
+      write(buf, " " & Msg) ;
+      -- Suffix
+      if Suffix /= "" then
+        write(buf, ' ' & Suffix) ;
+      end if ;
+      -- Time Last
+      if WriteTimeLast then
+        write(buf, " at " & to_string(LogTime, GetOsvvmDefaultTimeUnits)) ;
+      end if ;
+      WriteLine(buf) ;
+  end;
+
+end package body;

--- a/CommonLogPkgBody.vhd
+++ b/CommonLogPkgBody.vhd
@@ -7,23 +7,28 @@ package body CommonLogPkg is
 
   procedure WriteToLog(
     file LogDestination : text;
-    Msg : string := "";
+    LogDestinationPath : string := NoString;
+    Msg : string := NoString;
     LogTime : time := NoTime;
-    LogLevel : string := "";
-    LogSourceName : string := "";
+    LogLevel : string := NoString;
+    LogSourceName : string := NoString;
+
     Str1, Str2, Str3, Str4, Str5, Str6, Str7, Str8, Str9, Str10 : string := "";
-    Val1, Val2, Val3, Val4, Val5, Val6, Val7, Val8, Val9, Val10 : integer := NoVal) is
+    Int1, Int2, Int3, Int4, Int5, Int6, Int7, Int8, Int9, Int10 : integer := 0;
+    Bool1, Bool2, Bool3, Bool4, Bool5, Bool6, Bool7, Bool8, Bool9, Bool10 : boolean := false
+  ) is
       alias WritePrefix is Str1;
       alias WriteErrorCount is Str2;
       alias LogOrAlert is Str3;
       alias Prefix is Str4;
       alias Suffix is Str5;
 
-      alias AlertLogJustifyAmount is Val1;
-      constant WriteLevel : boolean := Val2 = 1;
-      constant WriteTimeFirst : boolean := Val3 = 1;
-      constant WriteTimeLast : boolean := Val4 = 1;
-      alias TimeJustifyAmount is Val5;
+      alias AlertLogJustifyAmount is Int1;
+      alias TimeJustifyAmount is Int2;
+
+      alias WriteLevel is Bool1;
+      alias WriteTimeFirst is Bool2;
+      alias WriteTimeLast is Bool3;
 
       variable buf : line ;
       ------------------------------------------------------------
@@ -53,7 +58,7 @@ package body CommonLogPkg is
         write(buf, "  " & LogLevel) ;
       end if ;
       -- AlertLog Name
-      if LogSourceName /= "" then
+      if LogSourceName /= NoString then
         write(buf, "   in " & LeftJustify(LogSourceName & ',', AlertLogJustifyAmount) ) ;
       end if ;
       -- Spacing before message

--- a/TranscriptPkg.vhd
+++ b/TranscriptPkg.vhd
@@ -11,7 +11,7 @@
 --  Description:
 --        Define file identifier TranscriptFile
 --        provide subprograms to open, close, and print to it.
---          
+--
 --
 --  Developed for:
 --        SynthWorks Design Inc.
@@ -31,86 +31,114 @@
 --
 --
 --  This file is part of OSVVM.
---  
---  Copyright (c) 2015 - 2020 by SynthWorks Design Inc.  
---  
+--
+--  Copyright (c) 2015 - 2020 by SynthWorks Design Inc.
+--
 --  Licensed under the Apache License, Version 2.0 (the "License");
 --  you may not use this file except in compliance with the License.
 --  You may obtain a copy of the License at
---  
+--
 --      https://www.apache.org/licenses/LICENSE-2.0
---  
+--
 --  Unless required by applicable law or agreed to in writing, software
 --  distributed under the License is distributed on an "AS IS" BASIS,
 --  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 --  See the License for the specific language governing permissions and
 --  limitations under the License.
---  
+--
 
 use std.textio.all ;
 use work.OsvvmScriptSettingsPkg.all ;
 package TranscriptPkg is
 
-  -- File Identifier to facilitate usage of one transcript file 
+  -- File Identifier to facilitate usage of one transcript file
   file             TranscriptFile : text ;
-  
+
   -- Cause compile errors if READ_MODE is passed to TranscriptOpen
-  subtype WRITE_APPEND_OPEN_KIND is FILE_OPEN_KIND range WRITE_MODE to APPEND_MODE ; 
-  
-  -- Open and close TranscriptFile.  Function allows declarative opens 
+  subtype WRITE_APPEND_OPEN_KIND is FILE_OPEN_KIND range WRITE_MODE to APPEND_MODE ;
+
+  -- Open and close TranscriptFile.  Function allows declarative opens
   procedure        TranscriptOpen (Status: InOut FILE_OPEN_STATUS; ExternalName: STRING; OpenKind: WRITE_APPEND_OPEN_KIND := WRITE_MODE) ;
-  procedure        TranscriptOpen (ExternalName: STRING; OpenKind: WRITE_APPEND_OPEN_KIND := WRITE_MODE) ;  
+  procedure        TranscriptOpen (ExternalName: STRING; OpenKind: WRITE_APPEND_OPEN_KIND := WRITE_MODE) ;
   impure function  TranscriptOpen (ExternalName: STRING; OpenKind: WRITE_APPEND_OPEN_KIND := WRITE_MODE) return FILE_OPEN_STATUS ;
   -- The following two are in ReportPkg to resolve circular depedencies
   --   procedure TranscriptOpen (OpenKind: WRITE_APPEND_OPEN_KIND := WRITE_MODE) ;
   --   procedure TranscriptOpen (Status: InOut FILE_OPEN_STATUS; OpenKind: WRITE_APPEND_OPEN_KIND := WRITE_MODE) ;
-  
-  procedure        TranscriptClose ;  
-  impure function  IsTranscriptOpen return boolean ; 
-  alias            IsTranscriptEnabled is IsTranscriptOpen [return boolean] ;  
-  
-  -- Mirroring.  When using TranscriptPkw WriteLine and Print, uses both TranscriptFile and OUTPUT 
-  procedure        SetTranscriptMirror (A : boolean := TRUE) ; 
-  impure function  IsTranscriptMirrored return boolean ; 
+
+  procedure        TranscriptClose ;
+  impure function  IsTranscriptOpen return boolean ;
+  alias            IsTranscriptEnabled is IsTranscriptOpen [return boolean] ;
+
+  -- Mirroring.  When using TranscriptPkw WriteLine and Print, uses both TranscriptFile and OUTPUT
+  procedure        SetTranscriptMirror (A : boolean := TRUE) ;
+  impure function  IsTranscriptMirrored return boolean ;
   alias            GetTranscriptMirror is IsTranscriptMirrored [return boolean] ;
 
   -- Write to TranscriptFile when open.  Write to OUTPUT when not open or IsTranscriptMirrored
-  procedure        WriteLine(buf : inout line)  ; 
-  procedure        Print(s : string) ; 
-  
+  procedure        WriteLine(buf : inout line)  ;
+  procedure        Print(s : string) ;
+
   -- Create "count" number of blank lines
   procedure BlankLine (count : integer := 1) ;
 
+  impure function GetTranscriptFilePath return string ;
+
 end TranscriptPkg ;
-  
+
 --- ///////////////////////////////////////////////////////////////////////////
 --- ///////////////////////////////////////////////////////////////////////////
 --- ///////////////////////////////////////////////////////////////////////////
 
 package body TranscriptPkg is
   ------------------------------------------------------------
-  type LocalBooleanPType is protected 
-    procedure Set (A : boolean) ; 
-    impure function get return boolean ; 
-  end protected LocalBooleanPType ; 
+  type LocalBooleanPType is protected
+    procedure Set (A : boolean) ;
+    impure function get return boolean ;
+  end protected LocalBooleanPType ;
   type LocalBooleanPType is protected body
-    variable GlobalVar : boolean := FALSE ; 
+    variable GlobalVar : boolean := FALSE ;
     procedure Set (A : boolean) is
     begin
-       GlobalVar := A ; 
-    end procedure Set ; 
+       GlobalVar := A ;
+    end procedure Set ;
     impure function get return boolean is
     begin
-      return GlobalVar ; 
-    end function get ; 
-  end protected body LocalBooleanPType ; 
-  
+      return GlobalVar ;
+    end function get ;
+  end protected body LocalBooleanPType ;
+
+  type LocalStringPType is protected
+    procedure Set (A : string) ;
+    impure function Get return string ;
+    procedure Clear;
+  end protected LocalStringPType ;
+  type LocalStringPType is protected body
+    variable GlobalVar : line := null ;
+    procedure Set (A : string) is
+    begin
+      deallocate(GlobalVar);
+      GlobalVar := new string'(A);
+    end procedure Set ;
+    impure function Get return string is
+    begin
+      if GlobalVar = null then
+        return "";
+      end if;
+      return GlobalVar.all ;
+    end function Get ;
+    procedure Clear is
+    begin
+      deallocate(GlobalVar);
+    end procedure Clear;
+  end protected body LocalStringPType ;
+
   file TranscriptYamlFile : text ;
-  
+
   ------------------------------------------------------------
-  shared variable TranscriptEnable : LocalBooleanPType ; 
-  shared variable TranscriptMirror : LocalBooleanPType ; 
-  shared variable TranscriptOpened : LocalBooleanPType ; 
+  shared variable TranscriptEnable : LocalBooleanPType ;
+  shared variable TranscriptMirror : LocalBooleanPType ;
+  shared variable TranscriptOpened : LocalBooleanPType ;
+  shared variable TranscriptFilePath : LocalStringPType ;
 
   ------------------------------------------------------------
   procedure CreateTranscriptYamlLog (Name : STRING) is
@@ -120,48 +148,49 @@ package body TranscriptPkg is
     -- Create Yaml file with list of files.
     if not TranscriptOpened.Get then
       file_open(TranscriptYamlFile, OSVVM_TRANSCRIPT_YAML_FILE, WRITE_MODE) ;
---      swrite(buf, "Transcripts: ") ; 
---      WriteLine(TranscriptYamlFile, buf) ; 
+--      swrite(buf, "Transcripts: ") ;
+--      WriteLine(TranscriptYamlFile, buf) ;
       TranscriptOpened.Set(TRUE) ;
     else
       file_open(TranscriptYamlFile, OSVVM_TRANSCRIPT_YAML_FILE, APPEND_MODE) ;
-    end if ; 
-    swrite(buf, "  - " & Name) ; 
-    WriteLine(TranscriptYamlFile, buf) ; 
+    end if ;
+    swrite(buf, "  - " & Name) ;
+    WriteLine(TranscriptYamlFile, buf) ;
     file_close(TranscriptYamlFile) ;
-  end procedure CreateTranscriptYamlLog ; 
+  end procedure CreateTranscriptYamlLog ;
 
   ------------------------------------------------------------
   procedure TranscriptOpen (Status: InOut FILE_OPEN_STATUS; ExternalName: STRING; OpenKind: WRITE_APPEND_OPEN_KIND := WRITE_MODE) is
   ------------------------------------------------------------
   begin
     file_open(Status, TranscriptFile, ExternalName, OpenKind) ;
-    
-    if Status = OPEN_OK then 
-      CreateTranscriptYamlLog(ExternalName) ; 
+
+    if Status = OPEN_OK then
+      CreateTranscriptYamlLog(ExternalName) ;
       TranscriptEnable.Set(TRUE) ;
-    end if ; 
-  end procedure TranscriptOpen ; 
-  
+      TranscriptFilePath.Set(ExternalName) ;
+    end if ;
+  end procedure TranscriptOpen ;
+
   ------------------------------------------------------------
   procedure TranscriptOpen (ExternalName: STRING; OpenKind: WRITE_APPEND_OPEN_KIND := WRITE_MODE) is
   ------------------------------------------------------------
-    variable Status : FILE_OPEN_STATUS ; 
+    variable Status : FILE_OPEN_STATUS ;
   begin
     TranscriptOpen(Status, ExternalName, OpenKind) ;
-    if Status /= OPEN_OK then 
-      report "TranscriptPkg.TranscriptOpen file: " & 
+    if Status /= OPEN_OK then
+      report "TranscriptPkg.TranscriptOpen file: " &
              ExternalName & " status is: " & to_string(status) & " and is not OPEN_OK" severity FAILURE ;
-    end if ; 
-  end procedure TranscriptOpen ; 
-  
+    end if ;
+  end procedure TranscriptOpen ;
+
   ------------------------------------------------------------
   impure function  TranscriptOpen (ExternalName: STRING; OpenKind: WRITE_APPEND_OPEN_KIND := WRITE_MODE) return FILE_OPEN_STATUS is
   ------------------------------------------------------------
-    variable Status : FILE_OPEN_STATUS ; 
+    variable Status : FILE_OPEN_STATUS ;
   begin
     TranscriptOpen(Status, ExternalName, OpenKind) ;
-    return Status ; 
+    return Status ;
   end function TranscriptOpen ;
 
   ------------------------------------------------------------
@@ -170,23 +199,24 @@ package body TranscriptPkg is
   begin
     if TranscriptEnable.Get then
       file_close(TranscriptFile) ;
-    end if ; 
+    end if ;
     TranscriptEnable.Set(FALSE) ;
-  end procedure TranscriptClose ; 
-  
+      TranscriptFilePath.Clear ;
+  end procedure TranscriptClose ;
+
   ------------------------------------------------------------
   impure function IsTranscriptOpen return boolean is
   ------------------------------------------------------------
   begin
     return TranscriptEnable.Get ;
   end function IsTranscriptOpen ;
-  
+
   ------------------------------------------------------------
-  procedure SetTranscriptMirror (A : boolean := TRUE) is 
+  procedure SetTranscriptMirror (A : boolean := TRUE) is
   ------------------------------------------------------------
   begin
       TranscriptMirror.Set(A) ;
-  end procedure SetTranscriptMirror ; 
+  end procedure SetTranscriptMirror ;
 
   ------------------------------------------------------------
   impure function IsTranscriptMirrored return boolean is
@@ -194,36 +224,43 @@ package body TranscriptPkg is
   begin
     return TranscriptMirror.Get ;
   end function IsTranscriptMirrored ;
-    
+
   ------------------------------------------------------------
-  procedure WriteLine(buf : inout line) is 
+  procedure WriteLine(buf : inout line) is
   ------------------------------------------------------------
   begin
     if not TranscriptEnable.Get then
-      WriteLine(OUTPUT, buf) ; 
+      WriteLine(OUTPUT, buf) ;
     elsif TranscriptMirror.Get then
-      TEE(TranscriptFile, buf) ; 
+      TEE(TranscriptFile, buf) ;
     else
-      WriteLine(TranscriptFile, buf) ; 
-    end if ; 
-  end procedure WriteLine ; 
+      WriteLine(TranscriptFile, buf) ;
+    end if ;
+  end procedure WriteLine ;
 
   ------------------------------------------------------------
-  procedure Print(s : string) is 
+  procedure Print(s : string) is
   ------------------------------------------------------------
-    variable buf : line ; 
+    variable buf : line ;
   begin
-    write(buf, s) ; 
-    WriteLine(buf) ; 
-  end procedure Print ; 
-  
+    write(buf, s) ;
+    WriteLine(buf) ;
+  end procedure Print ;
+
   ------------------------------------------------------------
   procedure BlankLine (count : integer := 1) is
   ------------------------------------------------------------
   begin
-    for i in 1 to count loop 
-      print("") ; 
+    for i in 1 to count loop
+      print("") ;
     end loop ;
-  end procedure Blankline ; 
+  end procedure Blankline ;
+
+  ------------------------------------------------------------
+  impure function GetTranscriptFilePath return string is
+  ------------------------------------------------------------
+  begin
+    return TranscriptFilePath.Get;
+  end function GetTranscriptFilePath ;
 
 end package body TranscriptPkg ;


### PR DESCRIPTION
This PR is a start for using the common log interface in `AlertLogPkg` as discussed in #80. It serves as a proof of concept and to see if the common log interface could work for OSVVM. I've focused on replacing `LocalPrint` procedure with a call to `WriteToLog` since most log entries goes through that procedure.

I think there are additional places in `AlertLogPkg` that can be considered as logging and should be refactored to use `WriteToLog` but I leave that for you to complete :-).

I realized that passing the path of the log destination, in case it is a file, to `WriteToLog` will make things easier on the implementation of that procedure so I added that to the interface.

The changes were made rather quickly and I see that there is potential for some cleaning.

Obviously the code has to be tested in the test suites to see that I didn't make any mistakes. I've only made visual inspections of a few `Log` and `Alert` calls.