### PR TITLE
Fix Simulate2HtmlHeader error on alert FAILURE

### DIFF
--- a/AlertLogPkg.vhd
+++ b/AlertLogPkg.vhd
@@ -1184,6 +1184,7 @@ package body AlertLogPkg is
               FileName        => OSVVM_OUTPUT_DIRECTORY & GetAlertLogName(ALERTLOG_BASE_ID) & "_alerts.yml"
             ) ;
           end if ;
+          TranscriptClose ;
           std.env.stop(ErrorCount) ;
         end if ;
       end if ;
@@ -1214,6 +1215,7 @@ package body AlertLogPkg is
           write(buf, " at " & to_string(NOW, 1 ns) & " ") ;
           writeline(buf) ;
           ReportAlerts(ReportWhenZero => TRUE) ;
+          TranscriptClose ;
           std.env.stop(ErrorCount) ;
         end if ;
       end if ;


### PR DESCRIPTION
When a tesbench fails on an Alert of type FAILURE, the following error results and the test report is not generated correctly. 

```
# ReportError: during Simulate2HtmlHeader 'Test Suite: DpRam,  TestCase: TbDpRam_BasicReadWrite ' failed: error renaming "TbDpRam_BasicReadWrite.txt" to "results/DpRam/TbDpRam_BasicReadWrite.txt": permission denied
# tcl errorInfo follows
# error renaming "TbDpRam_BasicReadWrite.txt" to "results/DpRam/TbDpRam_BasicReadWrite.txt": permission denied
#     while executing
# "file rename -force ${TranscriptFile}  ${CopyTargetFile}"
#     (procedure "LocalSimulate2HtmlHeader" line 61)
#     invoked from within
# "LocalSimulate2HtmlHeader $TestCaseName $TestSuiteName $BuildName $GenericList"
# ReportError: Simulate2Html failed.  See previous messages for details
```

This is due to the transcript not being closed. I added the lines in AlertLogPkg.vhd and this seems to have fixed the issue. 

Steps to reproduce:
Simply make an alert with severity failure fail, e.g. call an unimplemented transaction. 
