### PR TITLE
Fix unused CkMax in RandomPkg

### DIFF
--- a/RandomPkg.vhd
+++ b/RandomPkg.vhd
@@ -702,7 +702,7 @@ package body RandomPkg is
     ------------------------------------------------------------
       constant CkMax : integer := CheckMinMax("Uniform", Min, Max) ;
     begin
-      return LocalUniform (Min, Max, Exclude) ; 
+      return LocalUniform (Min, CkMax, Exclude) ;
     end function Uniform ;
 
 
@@ -1213,11 +1213,10 @@ package body RandomPkg is
     ------------------------------------------------------------
     impure function RandTime (Min, Max : time ; Exclude : time_vector ; Unit : time := ns) return time is
     ------------------------------------------------------------
-      variable IntVal : integer ;
       constant CkMax  : time := CheckMinMax("RandTime", Min, Max) ;
     begin
       --  if Min or Max > 2**31 value will be out of range
-      return RandInt(Min/Unit, Max/Unit, to_integer_vector(Exclude, Unit)) * Unit ;
+      return RandInt(Min/Unit, CkMax/Unit, to_integer_vector(Exclude, Unit)) * Unit ;
     end function RandTime ;
 
     ------------------------------------------------------------


### PR DESCRIPTION
I found this unused argument which  I suspect is a bug. I found it since I recently implemted an unused declaration warning in VHDL LS. OSVVM is one of the libraries I use for exploratory tests of VHDL LS.