### PR TITLE
Fix warning "(vcom-1246) Range 0 downto 1 is null" for Modelsim/Questa.

### DIFF
--- a/RandomBasePkg.vhd
+++ b/RandomBasePkg.vhd
@@ -83,8 +83,9 @@ package RandomBasePkg is
   constant OSVVM_RANDOM_ALERTLOG_ID : AlertLogIDType := OSVVM_ALERTLOG_ID ;
 
   -----------------------------------------------------------------
+  constant NULL_STRING : string := "";
   -- note NULL_RANGE_TYPE should probably be in std.standard
-  subtype NULL_RANGE_TYPE is integer range 0 downto 1 ;
+  subtype NULL_RANGE_TYPE is integer range NULL_STRING'range ;
   constant NULL_INTV : integer_vector (NULL_RANGE_TYPE) := (others => 0) ;
 
   -----------------------------------------------------------------


### PR DESCRIPTION
This is a minor fix to avoid unnecessary warnings with Questa and Modelsim.
