### PR TITLE
Only analyse FileLinePathPkg if VhdlVersion >= 2019

### DIFF
--- a/osvvm.pro
+++ b/osvvm.pro
@@ -74,7 +74,7 @@ analyze CoverageVendorApiPkg_${::osvvm::FunctionalCoverageIntegratedInSimulator}
 
 analyze TranscriptPkg.vhd
 
-if {$::osvvm::Support2019FilePath} {
+if {$::osvvm::Support2019FilePath && $::osvvm::VhdlVersion >= 2019} {
   analyze FileLinePathPkg.vhd
 } else {
   analyze deprecated/FileLinePathPkg_c.vhd


### PR DESCRIPTION
I have a script that compiles OSVVM for both 2019 and 2008. In the latter case I call `SetVhdlVersion 2008` before sourcing `OsvvmLibraries.pro` but after `Scripts/StartNVC.tcl` and by that point `Support2019FilePath` is already true.
